### PR TITLE
fix(mcp): update tool name to use snake_case

### DIFF
--- a/src/core/cal2prompt.rs
+++ b/src/core/cal2prompt.rs
@@ -154,7 +154,7 @@ impl Cal2Prompt {
                                 if let Some(tool_name) =
                                     params_val.get("name").and_then(Value::as_str)
                                 {
-                                    if tool_name == "list-calendar-events" {
+                                    if tool_name == "list_calendar_events" {
                                         let since_str = params_val
                                             .pointer("/arguments/since")
                                             .and_then(Value::as_str)

--- a/src/core/mcp/tools.json
+++ b/src/core/mcp/tools.json
@@ -1,7 +1,7 @@
 {
   "tools": [
     {
-      "name": "list-calendar-events",
+      "name": "list_calendar_events",
       "description": "Retrieves events from Google Calendar within the specified time range. Format: yyyy-MM-dd or yyyy-MM-dd HH:mm. (Currently we only parse yyyy-MM-dd).",
       "inputSchema": {
         "type": "object",


### PR DESCRIPTION
Cursor doesn’t recognize tools with dashes. related [here](https://forum.cursor.com/t/cursor-refuses-to-use-my-mcp-server/51709/3).